### PR TITLE
Increased sleep after messages

### DIFF
--- a/src/main/java/GameEngine.java
+++ b/src/main/java/GameEngine.java
@@ -89,7 +89,7 @@ public class GameEngine {
                     break;
                 case 2:
                     actionPhase();
-                    sleep(1500);
+                    sleep(2000);
                     break;
                 case 3:
                     getActivePlayer().passTurn(true);
@@ -97,7 +97,7 @@ public class GameEngine {
                     break;
                 default:
                     System.out.println("\033[0;101m\033[1;97mInvalid choice!\033[0m");
-                    sleep(1000);
+                    sleep(2000);
             }
             moveAllDeadCardsToGraveYard();
             resolveEffect(resolvePlay);
@@ -114,13 +114,13 @@ public class GameEngine {
                     int healAmount = Math.abs(Integer.parseInt(effectComponents[2]));
                     getActivePlayer().heal(healAmount);
                     System.out.println("\033[0;93mYou healed \033[0m" + effectComponents[2] + "\033[0;93m HP!\033[0m");
-                    sleep(1000);
+                    sleep(2000);
                 }
                 break;
             case "ATTACK":
                 int damage = Math.abs(Integer.parseInt(effectComponents[2]));
                 getInactivePlayer().setHp(getInactivePlayer().getHp() - damage);
-                sleep(1000);
+                sleep(2000);
             case "RUSH":
                 Card card = getActivePlayer().getTable().get(getActivePlayer().getTable().size() - 1);
                 ((CreatureCard) card).setActive(true);
@@ -146,7 +146,7 @@ public class GameEngine {
             attack();
         } else {
             System.out.println("\033[1;93mYou have no cards you can attack with!\033[0m");
-            sleep(1000);
+            sleep(2000);
         }
     }
 

--- a/src/main/java/Player.java
+++ b/src/main/java/Player.java
@@ -75,7 +75,7 @@ public class Player {
             graveyard.add(deck.get(0));
             deck.remove(0);
             System.out.println("\033[0;93mHand full, the card is moved straight to Graveyeard\n\033[0m");
-            sleep(1000);
+            sleep(2000);
             return false;
         } else {
             hand.add(deck.get(0));
@@ -160,7 +160,7 @@ public class Player {
             return true;
         } else {
             System.out.println("\033[0;93mNot enough mana!\n\033[0m");
-            sleep(1000);
+            sleep(2000);
             return false;
         }
     }


### PR DESCRIPTION
Enterpreted it that all messages in the game should have an equal amount of sleep of 2000 ms. All except one, when active player is switched, which is still 3000 ms.